### PR TITLE
Lexical or Preprocessor Issue (Xcode): 'FlutterMobileVisionPlugin.h' file not found

### DIFF
--- a/ios/Classes/FlutterMobileVision_2Plugin.m
+++ b/ios/Classes/FlutterMobileVision_2Plugin.m
@@ -1,4 +1,4 @@
-#import "FlutterMobileVisionPlugin.h"
+#import "FlutterMobileVision_2Plugin.h"
 
 @implementation FlutterMobileVisionPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {


### PR DESCRIPTION
Lexical or Preprocessor Issue (Xcode): 'FlutterMobileVisionPlugin.h' file not
found
/Users/nullplexsoftware/.pub-cache/git/flutter_mobile_vision_2-8024e97efb1ca8ed3
80dfd8be554d0f986979a4c/ios/Classes/FlutterMobileVision_2Plugin.m:0:8


Could not build the application for the simulator.
Error launching application on iPhone 14 Pro Max.